### PR TITLE
Added initial support for Silo deployments.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -64,6 +64,13 @@ cli
         throw new Error('--content-type: Invalid content-type, must be a valid mime type in the format of */*, e.g. text/html');
     })
 
+cli
+    .option('--silo <silo_name>', 'Deploy with Silo using this name.', (value: string): string => {
+        if (value.match(/[a-zA-Z0-9]+\.[0-9]+/)) {
+            return value;
+        }
+        throw new Error('--silo: Invalid Silo name, must be a name in the format of [a-zA-Z0-9]+.[0-9]+, e.g. \'bubble.7\'');
+    })
 
 commands.forEach( instance => {
 

--- a/src/lib/silo.js
+++ b/src/lib/silo.js
@@ -1,0 +1,20 @@
+// Output an object containing the given `access` and `decrypt` keys given the 
+// input name.
+import * as crypto from 'crypto';
+export function parseName(raw_name) {
+    let parts = raw_name.split('.');
+    let name = parts[0];
+    let hash_count = Math.pow(2, parseInt(parts[1]));
+    let hash = crypto.createHash('sha256').update(name);
+
+    for(let i = 0; i < hash_count; i++) {
+        hash.update(name);
+    }
+    
+    let total_buffer = hash.digest();
+
+    let silo_ref = {};
+    silo_ref.access = total_buffer.slice(0, 15);
+    silo_ref.decrypt = total_buffer.slice(16, 31);
+    return silo_ref;
+}


### PR DESCRIPTION
This current results in a 400, transaction rejected, but that does not seem to be a result of the Silo side?

Couple of points to note:
- Extracting the content type (and the silo name) wasn't working. The new solution is funky -- is there a better one?
- Perhaps we don't want to pollute the nice TypeScript codebase with my crappy JS?