### PR TITLE
fix css parser bug

### DIFF
--- a/src/parsers/text-html.ts
+++ b/src/parsers/text-html.ts
@@ -60,15 +60,20 @@ const importCssUrls = async (source: any, context: any, logger: Function): Promi
         const cssUrl = match[1];
 
         // Remove any quotes or whitespace that might be encasing the path as it's perfectly valid in CSS
-        // but we need clean path to work with. remove any query params or # locations as they won't be valid paths.
         let path = cssUrl.replace(/^'\//g, '').replace(/('|")/g, '').trim();
+        
+        // remove any query params or # locations as they won't be valid paths.
+        path = path.replace(/(\#|\?).*/, '');
+
+        // continue, if path is empty string, this will happen if url happens to be just #location
+        if(!path){
+            continue;
+        }
 
         // Only import local resources, so don't import https/s externals.
         if (path.startsWith('data') || path.startsWith('http')) {
             continue;
         }
-
-        path = path.replace(/(\#|\?).*/, '');
 
         const resource = new File(path, dirname(source.filepath));
 


### PR DESCRIPTION
The parser threw this error if the css file contains a `#location`: 
`EISDIR: illegal operation on a directory, read`

This is because, after we remove '#location' from path in here: 
https://github.com/ArweaveTeam/arweave-deploy/blob/f296c456986dbb3473f29b65ad07b4f93c35020e/src/parsers/text-html.ts#L71

the path becomes an empty string. and when we try to create resource from empty string path, it points to parent directory which  throws an error because we're trying to read content from directory instead of file. 

This PR fixes it. If the path is empty string, we simply skip trying to read the resource and move on to next. 