### PR TITLE
Avoid <link> wrapping tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "axios": "^0.19.0",
     "chai": "^4.2.0",
     "commander": "^2.20.0",
-    "inline-source": "^6.2.0",
+    "inline-source": "^7.1.0",
     "ipfs-unixfs": "^0.1.16",
     "ipld-dag-pb": "^0.17.4",
     "mime": "^2.4.4",

--- a/src/parsers/text-html.ts
+++ b/src/parsers/text-html.ts
@@ -202,7 +202,7 @@ const importCssUrls = async (entry: File, source: Source, context: any, logger: 
     }
 
     if (output !== css) {
-        source.content = `<style>\n${output}\n</style>`
+        source.replace = `<style>\n${output}\n</style>`
     }
 }
 

--- a/src/parsers/text-html.ts
+++ b/src/parsers/text-html.ts
@@ -98,7 +98,7 @@ const importRemoteImages = async (entry: File, source: Source, context: any, log
 const importCssUrls = async (entry: File, source: Source, context: any, logger: Function): Promise<void> =>  {
 
     let css = source.fileContent as string;
-    let output = `<style>\n${css}\n</style>`;
+    let output = css;
 
     const urlRegexGlobal = /.*url\(([^\)]+)\).*/gi;
 
@@ -201,7 +201,9 @@ const importCssUrls = async (entry: File, source: Source, context: any, logger: 
         }
     }
 
-    source.content = output;
+    if (output !== css) {
+        source.content = `<style>\n${output}\n</style>`
+    }
 }
 
 async function downloadRemote(url: string): Promise<{data: Buffer, type: string}>{


### PR DESCRIPTION
I wonder why the [W3C validator noticed an HTML error](https://validator.w3.org/nu/?doc=https%3A%2F%2Farweave.net%2F4GesEQi3pgLyGYc68-CzihN5SIaatOh0pY3W4we5nko) on every Arweave static page. _Arweave Deploy_ generates an empty `<link>` tag which comes after inlining the CSS files. 

[Regarding to the PR](https://github.com/popeindustries/inline-source/pull/139), my patch fixes the problem.
