### PR TITLE
Update arweave-js dep to ^1.6.0 and misc small fixes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arweave-deploy",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "arweave-deploy",
   "main": "dist/arweave",
   "devDependencies": {
@@ -10,7 +10,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.14.13",
     "@types/promptly": "^1.1.28",
-    "arweave": "github:arweaveteam/arweave-js#4a6b820fa74f0a8f98e7cbe70fcc95f372a95820",
+    "arweave": "^1.6.0",
     "axios": "^0.19.0",
     "chai": "^4.2.0",
     "cli-progress": "^3.3.1",

--- a/src/commands/deploy-dir.ts
+++ b/src/commands/deploy-dir.ts
@@ -75,7 +75,7 @@ export class DeployDirCommand extends Command {
         const assets = await this.getAssets(this.cwd, path);
 
         if (assets.length > 100) {
-            throw new Error(`A maximum of 50 files per directory is currently supported.`);
+          throw new Error(`A maximum of 100 files per directory is currently supported.`);
         }
 
         const transactions: Transaction[] = [];

--- a/src/lib/TransactionBuilder.ts
+++ b/src/lib/TransactionBuilder.ts
@@ -87,7 +87,7 @@ export async function parseData(file: File, options: PrepareTransactionOptions):
 
     const data = await parser.run(file, options);
 
-    if (data.byteLength >= 2 * 1024 * 1024) {
+    if (data.byteLength > 10 * 1024 * 1024) {
         throw new Error(`Detected byte size: ${File.bytesForHumans(data.byteLength)}\nData uploads are currently limited to 10MB per transaction.`);
     }
 

--- a/src/lib/ipfs.ts
+++ b/src/lib/ipfs.ts
@@ -2,7 +2,7 @@
 import * as dagPB from 'ipld-dag-pb';
 
 //@ts-ignore
-import * as UnixFS from 'ipfs-unixfs';
+import UnixFS from 'ipfs-unixfs';
 
 export async function getIpfsCid(data: Buffer, unixFsType = 'file', dagPbOptions = {cidVersion: 0}): Promise<string>{
     const file = new UnixFS(unixFsType, data);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "allowJs": true,
         "moduleResolution": "node",
         "rootDir": "src",
+        "esModuleInterop": true
     },
     "include": [
         "src"


### PR DESCRIPTION
Redid this PR to only be bugfix, will work as is but to get the full 10MB tx supported, 
needs:  https://github.com/ArweaveTeam/arweave-js/pull/30 

Will work without, but files somewhere above 7MB will generate an axios error.
