### PR TITLE
Update TransactionBuilder.ts

### DIFF
--- a/src/lib/TransactionBuilder.ts
+++ b/src/lib/TransactionBuilder.ts
@@ -87,7 +87,7 @@ export async function parseData(file: File, options: PrepareTransactionOptions):
 
     const data = await parser.run(file, options);
 
-    if (data.byteLength >= 2 * 1024 * 1024) {
+    if (data.byteLength >= 10 * 1024 * 1024) {
         throw new Error(`Detected byte size: ${File.bytesForHumans(data.byteLength)}\nData uploads are currently limited to 10MB per transaction.`);
     }
 


### PR DESCRIPTION
Set `data.byteLength` to `10 * 1024 * 1024` according to the message "Data uploads are currently limited to 10MB per transaction."