### PR TITLE
More suggestions on example documentation.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -158,8 +158,8 @@ cli.on('--help', function() {
     log('Examples:');
     log('  Without a saved key file');
     log('    arweave deploy index.html --key-file path/to/my/keyfile.json');
-    log('    arweave save-key --key-file path/to/my/keyfile.json');
     log('    arweave balance --key-file path/to/my/keyfile.json');
+    log('    arweave save-key path/to/my/keyfile.json');
     log('  With a saved key file');
     log('    arweave deploy index.html');
     log('    arweave balance');


### PR DESCRIPTION
The "--key-file" parameter also brings an error because the command itself wants the location, and I believe should be removed. I would also put the save key example after the other two, since it leads to the next pattern.